### PR TITLE
The Provider class suffix can be passed from the command line.

### DIFF
--- a/src/main/java/com/hsiaosiyuan/jexpose/App.java
+++ b/src/main/java/com/hsiaosiyuan/jexpose/App.java
@@ -9,13 +9,13 @@ import java.util.concurrent.ExecutionException;
 public class App {
 
   public static void main(String[] args) throws IOException, ExecutionException, InterruptedException, ZipException {
-    if (args.length != 3)
-      throw new IllegalArgumentException("please specify `entry` `entryJarPath` `libDirPath`");
+    if (args.length != 4)
+      throw new IllegalArgumentException("please specify `entry` `entryJarPath` `libDirPath` `providerSuffix`");
 
     PrintStream out = new PrintStream(System.out, true, "UTF-8");
     System.setOut(out);
     long tb = System.currentTimeMillis();
-    String outDir = new ProvidersDeflator(args[0], args[1], args[2]).process();
+    String outDir = new ProvidersDeflator(args[0], args[1], args[2],args[3]).process();
     long te = System.currentTimeMillis();
     double elapsed = (te - tb) / 1000.0;
     System.out.println("Output at: " + outDir);

--- a/src/main/java/com/hsiaosiyuan/jexpose/ProvidersDeflator.java
+++ b/src/main/java/com/hsiaosiyuan/jexpose/ProvidersDeflator.java
@@ -23,6 +23,7 @@ public class ProvidersDeflator {
   private String entryName;
   private File entryJar;
   private File libDir;
+  private String providerSuffix;
 
   private ArrayList<String> providerNames;
   private HashMap<String, ClassSignature> resolvedProviders;
@@ -31,7 +32,8 @@ public class ProvidersDeflator {
   private static File extractedDir;
   private static File outputDir;
 
-  public ProvidersDeflator(String entry, String entryJarPath, String libDirPath) {
+  public ProvidersDeflator(String entry, String entryJarPath, String libDirPath, String providerSuffix) {
+    this.providerSuffix = providerSuffix;
     entryName = entry;
 
     File file = new File(entryJarPath);
@@ -101,7 +103,7 @@ public class ProvidersDeflator {
     for (File f : files) {
       if (f.isDirectory()) {
         ret.addAll(walkAndScanProviders(root, f));
-      } else if (FilenameUtils.getBaseName(f.getName()).endsWith("Provider")) {
+      } else if (FilenameUtils.getBaseName(f.getName()).endsWith(this.providerSuffix)) {
         String relativePath = f.getAbsolutePath().replace(root, "");
         String name = FilenameUtils.removeExtension(relativePath).replace(File.separator, ".");
         ret.add(entryName + name);


### PR DESCRIPTION
Set the default values in the [interpret-cli's extra function](https://github.com/dubbo/dubbo2.js/blob/master/packages/interpret-cli/src/ext/index.ts#L29) library and can be customized. 
For example:

```typescript
 let execCmd = spawn(`java`, [
      '-jar',
      join(__dirname, '../../ext/jexpose-1.1.jar'),
      extraParam.entry,
      extraParam.entryJarPath,
      extraParam.libDirPath,
      extraParam.providerSuffix || 'Provider'
    ]);
```